### PR TITLE
Add automated Notion content sync workflow

### DIFF
--- a/.github/workflows/sync-notion.yml
+++ b/.github/workflows/sync-notion.yml
@@ -1,0 +1,41 @@
+name: Sync Notion Content
+
+on:
+  schedule:
+    # Runs daily at 6:00 AM UTC
+    - cron: '0 6 * * *'
+  workflow_dispatch: # Allow manual trigger from GitHub UI
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+
+      - uses: pnpm/action-setup@v2
+        with:
+          version: latest
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Sync from Notion
+        env:
+          NOTION_TOKEN: ${{ secrets.NOTION_TOKEN }}
+          BLOB_READ_WRITE_TOKEN: ${{ secrets.BLOB_READ_WRITE_TOKEN }}
+        run: pnpm sync
+
+      - name: Commit and push changes
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add .content/ public/notion-images/
+          if git diff --cached --quiet; then
+            echo "No changes to commit"
+          else
+            git commit -m "sync: update content from Notion"
+            git push
+          fi


### PR DESCRIPTION
## Summary
This PR introduces an automated GitHub Actions workflow that syncs content from Notion to the repository on a scheduled basis.

## Key Changes
- Added `.github/workflows/sync-notion.yml` workflow file that:
  - Runs daily at 6:00 AM UTC via cron schedule
  - Supports manual triggering via `workflow_dispatch`
  - Sets up Node.js 18 and pnpm environment
  - Executes the `pnpm sync` command to pull content from Notion
  - Automatically commits and pushes changes to `.content/` and `public/notion-images/` directories
  - Uses GitHub Actions bot credentials for commits
  - Safely handles cases where no changes are present

## Implementation Details
- Leverages GitHub secrets for `NOTION_TOKEN` and `BLOB_READ_WRITE_TOKEN` authentication
- Uses `--frozen-lockfile` to ensure reproducible dependency installation
- Includes conditional commit logic to avoid empty commits
- Configured to run unattended with appropriate bot user identity

https://claude.ai/code/session_01NBnoB6eohVnUWCeE4QwX5u