### PR TITLE
fix(ci): use Node 22 for sync workflow

### DIFF
--- a/.github/workflows/sync-notion.yml
+++ b/.github/workflows/sync-notion.yml
@@ -14,7 +14,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 22
 
       - uses: pnpm/action-setup@v2
         with:


### PR DESCRIPTION
Node 18 doesn't support the --env-file flag used by pnpm sync. Node 22 supports it natively.

https://claude.ai/code/session_01NBnoB6eohVnUWCeE4QwX5u