### PR TITLE
fix(ci): write .env file from secrets before sync

### DIFF
--- a/.github/workflows/sync-notion.yml
+++ b/.github/workflows/sync-notion.yml
@@ -14,7 +14,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: 22
+          node-version: 18
 
       - uses: pnpm/action-setup@v2
         with:
@@ -22,10 +22,12 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
+      - name: Create .env file
+        run: |
+          echo "NOTION_TOKEN=${{ secrets.NOTION_TOKEN }}" >> .env
+          echo "BLOB_READ_WRITE_TOKEN=${{ secrets.BLOB_READ_WRITE_TOKEN }}" >> .env
+
       - name: Sync from Notion
-        env:
-          NOTION_TOKEN: ${{ secrets.NOTION_TOKEN }}
-          BLOB_READ_WRITE_TOKEN: ${{ secrets.BLOB_READ_WRITE_TOKEN }}
         run: pnpm sync
 
       - name: Commit and push changes


### PR DESCRIPTION
The sync script uses tsx --env-file=.env which requires the file to exist. Write it from GitHub secrets instead of passing env vars directly. Also reverts back to Node 18 since --env-file is handled by tsx, not node.

https://claude.ai/code/session_01NBnoB6eohVnUWCeE4QwX5u