### PR TITLE
fix(ci): only stage notion-images if directory exists

### DIFF
--- a/.github/workflows/sync-notion.yml
+++ b/.github/workflows/sync-notion.yml
@@ -34,7 +34,8 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add .content/ public/notion-images/
+          git add .content/
+          if [ -d public/notion-images ]; then git add public/notion-images/; fi
           if git diff --cached --quiet; then
             echo "No changes to commit"
           else


### PR DESCRIPTION
Images are uploaded to Vercel Blob, so public/notion-images/ may not exist locally. Only git add it if present.

https://claude.ai/code/session_01NBnoB6eohVnUWCeE4QwX5u