### PR TITLE
fix(ci): create PR instead of pushing to main

### DIFF
--- a/.github/workflows/sync-notion.yml
+++ b/.github/workflows/sync-notion.yml
@@ -30,7 +30,9 @@ jobs:
       - name: Sync from Notion
         run: pnpm sync
 
-      - name: Commit and push changes
+      - name: Commit and create PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -38,7 +40,13 @@ jobs:
           if [ -d public/notion-images ]; then git add public/notion-images/; fi
           if git diff --cached --quiet; then
             echo "No changes to commit"
-          else
-            git commit -m "sync: update content from Notion"
-            git push
+            exit 0
           fi
+          BRANCH="sync/notion-$(date +%Y-%m-%d)"
+          git checkout -b "$BRANCH"
+          git commit -m "sync: update content from Notion"
+          git push -u origin "$BRANCH"
+          gh pr create \
+            --title "sync: update content from Notion ($(date +%Y-%m-%d))" \
+            --body "Automated sync of latest Notion content." \
+            --reviewer leothesen


### PR DESCRIPTION
Main branch is protected and requires a PR. Updated the sync workflow to push to a dated branch and open a PR with leothesen as reviewer.

https://claude.ai/code/session_01NBnoB6eohVnUWCeE4QwX5u