### PR TITLE
fix: critical security and stability issues from audit

### DIFF
--- a/lib/notion-local.ts
+++ b/lib/notion-local.ts
@@ -60,8 +60,15 @@ export function getLocalPage(pageId: string): LocalPageData | null {
 
   if (!fs.existsSync(metaPath) || !fs.existsSync(blocksPath)) return null
 
-  const meta = JSON.parse(fs.readFileSync(metaPath, 'utf-8'))
-  const blocks = JSON.parse(fs.readFileSync(blocksPath, 'utf-8'))
+  let meta: LocalPageData['meta']
+  let blocks: NotionBlock[]
+  try {
+    meta = JSON.parse(fs.readFileSync(metaPath, 'utf-8'))
+    blocks = JSON.parse(fs.readFileSync(blocksPath, 'utf-8'))
+  } catch (err) {
+    console.error(`Corrupted cache file for page ${pageId}:`, err)
+    return null
+  }
 
   // Load database entries
   const databaseEntries: Record<string, DatabaseEntry[]> = {}
@@ -70,7 +77,11 @@ export function getLocalPage(pageId: string): LocalPageData | null {
     const dbFiles = fs.readdirSync(dbDir).filter((f) => f.endsWith('.json'))
     for (const dbFile of dbFiles) {
       const dbId = dbFile.replace('.json', '')
-      databaseEntries[dbId] = JSON.parse(fs.readFileSync(path.join(dbDir, dbFile), 'utf-8'))
+      try {
+        databaseEntries[dbId] = JSON.parse(fs.readFileSync(path.join(dbDir, dbFile), 'utf-8'))
+      } catch (err) {
+        console.error(`Corrupted database cache ${dbFile} for page ${pageId}:`, err)
+      }
     }
   }
 

--- a/pages/[...pageId].tsx
+++ b/pages/[...pageId].tsx
@@ -14,7 +14,7 @@ export const getStaticProps: GetStaticProps = async (context) => {
     return { props: JSON.parse(JSON.stringify(props)) }
   } catch (err) {
     console.error('page error', domain, rawPageId, err)
-    throw err
+    return { notFound: true }
   }
 }
 

--- a/pages/api/search-notion.ts
+++ b/pages/api/search-notion.ts
@@ -2,9 +2,28 @@ import { NextApiRequest, NextApiResponse } from 'next'
 
 import { searchNotion, getPageTitle, getPageCover } from '@/lib/notion-api'
 
+const rateLimit = new Map<string, number[]>()
+const RATE_LIMIT_WINDOW_MS = 60 * 1000
+const RATE_LIMIT_MAX = 10
+
+function isRateLimited(ip: string): boolean {
+  const now = Date.now()
+  const timestamps = rateLimit.get(ip) ?? []
+  const recent = timestamps.filter((t) => now - t < RATE_LIMIT_WINDOW_MS)
+  if (recent.length >= RATE_LIMIT_MAX) return true
+  recent.push(now)
+  rateLimit.set(ip, recent)
+  return false
+}
+
 export default async (req: NextApiRequest, res: NextApiResponse) => {
   if (req.method !== 'POST') {
     return res.status(405).send({ error: 'method not allowed' })
+  }
+
+  const ip = (req.headers['x-forwarded-for'] as string)?.split(',')[0]?.trim() ?? req.socket.remoteAddress ?? 'unknown'
+  if (isRateLimited(ip)) {
+    return res.status(429).json({ error: 'too many requests' })
   }
 
   const { query } = req.body

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -10,7 +10,7 @@ export const getStaticProps = async () => {
     return { props: JSON.parse(JSON.stringify(props)) }
   } catch (err) {
     console.error('page error', domain, err)
-    throw err
+    return { notFound: true }
   }
 }
 


### PR DESCRIPTION
## Summary

- **Rate limit search API** — adds in-memory per-IP rate limiting (10 req/min) to `pages/api/search-notion.ts` to prevent abuse
- **Fix getStaticProps error handling** — returns `{ notFound: true }` instead of throwing in `pages/[...pageId].tsx` and `pages/index.tsx`, preventing 500 errors for missing pages
- **Wrap JSON.parse in try-catch** — `lib/notion-local.ts` now gracefully handles corrupted cache files by returning null instead of crashing

## Test plan

- [ ] Verify search API returns 429 after 10 rapid requests from same IP
- [ ] Verify missing/invalid page routes return 404 instead of 500
- [ ] Verify corrupted `.content` cache files don't crash the build

🤖 Generated with [Claude Code](https://claude.com/claude-code)